### PR TITLE
Add a default User-Agent String

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Amazon Cognito Identity SDK for JavaScript for Node.js
 
-This module is a fork of [amazon-cognito-identity-js](https://github.com/aws/amazon-cognito-identity-js) and applicable to Node.js
+This module was originally a forked from [amazon-cognito-identity-js](https://github.com/aws/amazon-cognito-identity-js) to [amazon-cognito-identity-js-node](https://github.com/kndt84/amazon-cognito-identity-js). I have since forked it again as the owner of the fork does not seem to be accepting pull requests.
+
+I made updates to the codebase to sent a mock User Agent string in the HTTPS Requests, failure to do this causes errors like this: 
+```shell
+ReferenceError: navigator is not defined
+    at CognitoUser.authenticateUserInternal (node_modules/amazon-cognito-identity-js/lib/CognitoUser.js:343:19)
+```
 
 ## Install
 ```sh

--- a/src/CognitoUser.js
+++ b/src/CognitoUser.js
@@ -293,7 +293,7 @@ module.exports = class CognitoUser {
       DeviceKey: newDeviceMetadata.DeviceKey,
       AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
       DeviceSecretVerifierConfig: deviceSecretVerifierConfig,
-      DeviceName: navigator.userAgent,
+      DeviceName: 'nodejs-https/amazon-cognito-identity-js-node',
     }, (errConfirm, dataConfirm) => {
       if (errConfirm) {
         return callback.onFailure(errConfirm);
@@ -552,7 +552,7 @@ module.exports = class CognitoUser {
         DeviceKey: dataAuthenticate.AuthenticationResult.NewDeviceMetadata.DeviceKey,
         AccessToken: this.signInUserSession.getAccessToken().getJwtToken(),
         DeviceSecretVerifierConfig: deviceSecretVerifierConfig,
-        DeviceName: navigator.userAgent,
+        DeviceName: 'nodejs-https/amazon-cognito-identity-js-node',
       }, (errConfirm, dataConfirm) => {
         if (errConfirm) {
           return callback.onFailure(errConfirm);


### PR DESCRIPTION
While attempting to log in, I found the following error: `ReferenceError: navigator is not defined`

```
ReferenceError: navigator is not defined
    at CognitoUser.authenticateUserInternal (node_modules/amazon-cognito-identity-js/lib/CognitoUser.js:343:19)
```
I added a default UserAgent string for this library: `nodejs-https/amazon-cognito-identity-js-node`.

Now I am able to authenticate.
